### PR TITLE
Method to store user authentication credentials for first time

### DIFF
--- a/app/controllers/crons_controller.rb
+++ b/app/controllers/crons_controller.rb
@@ -1,6 +1,18 @@
 class CronsController < ApplicationController
   require 'rest-client'
 
+  # This only needs to be called the first time we add a new user
+  # We will call it manually for now (e.g. via postman) to store their first set of session_token and access_token credentials in DB
+  # Once this first set of tokens is stored, all subsequent attempts to authenticate will use the tokens stored in DB
+  def first_time_authentication
+    user_id = parse_param(param, "user_id")
+    session_token = parse_param(param, "session_token")
+    refresh_token = parse_param(param, "refresh_token")
+    session_token_expiry = parse_param(param, "session_token_expiry")
+
+    User.new  
+  end
+
   def start
     user_id = "fillIn"
     access_token = "fillIn"
@@ -8,4 +20,15 @@ class CronsController < ApplicationController
     res = RestClient.get("https://api.fitbit.com/1.2/user/#{user_id}/sleep/date/#{date}.json", headers={authorization: "Bearer #{access_token}"})
     p res.to_yaml
   end
+
+  private
+  def parse_param(params, key)
+    param = params[key]
+    if !param do
+        raise "missing param #{key}"
+    end
+
+    return param
+  end
+
 end

--- a/app/controllers/crons_controller.rb
+++ b/app/controllers/crons_controller.rb
@@ -4,13 +4,18 @@ class CronsController < ApplicationController
   # This only needs to be called the first time we add a new user
   # We will call it manually for now (e.g. via postman) to store their first set of session_token and access_token credentials in DB
   # Once this first set of tokens is stored, all subsequent attempts to authenticate will use the tokens stored in DB
-  def first_time_authentication
-    user_id = parse_param(param, "user_id")
-    session_token = parse_param(param, "session_token")
-    refresh_token = parse_param(param, "refresh_token")
-    session_token_expiry = parse_param(param, "session_token_expiry")
+  def new_user
+    user_id = parse_param(params, "user_id")
+    session_token = parse_param(params, "session_token")
+    refresh_token = parse_param(params, "refresh_token")
+    session_token_expiry = parse_param(params, "session_token_expiry")
 
-    User.new  
+    @user = User.new(user_id: user_id, session_token: session_token, refresh_token: refresh_token, session_token_expiry: session_token_expiry)
+    if @user.save
+        p "🎉🎉🎉 User successfully saved 🎉🎉🎉"
+    else
+        p "There was a problem saving this user"
+    end
   end
 
   def start
@@ -24,7 +29,7 @@ class CronsController < ApplicationController
   private
   def parse_param(params, key)
     param = params[key]
-    if !param do
+    if !param || param == ""
         raise "missing param #{key}"
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get '/', to: 'crons#start'
+
+  post '/users', to: 'crons#new_user'
 end

--- a/db/migrate/20230103202742_create_users.rb
+++ b/db/migrate/20230103202742_create_users.rb
@@ -1,7 +1,7 @@
 class CreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|
-      t.integer :user_id
+      t.string :user_id
       t.string :session_token
       t.string :refresh_token
       t.timestamp :session_token_expiry

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2023_01_03_202742) do
 
   create_table "users", force: :cascade do |t|
-    t.integer "user_id"
+    t.string "user_id"
     t.string "session_token"
     t.string "refresh_token"
     t.datetime "session_token_expiry"


### PR DESCRIPTION
- Provides a method to store a new user's authentication credentials for the first time
- Fixes a DB error where the user_id was being stored as integer instead of a string
!!! NB you will need to rollback the changes on your local DB and re-migrate !!!

